### PR TITLE
Explicitly raise an error if `MAXMIND_LICENSE_KEY` is not set

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,13 @@
 import Config
 
 config :geo,
-  maxmind_license_key: System.get_env("MAXMIND_LICENSE_KEY")
+  maxmind_license_key:
+    System.get_env("MAXMIND_LICENSE_KEY") ||
+      raise("""
+      environment variable MAXMIND_LICENSE_KEY not set
+      This key is needed to download the IP database
+
+      For more information, refer to https://support.maxmind.com/hc/en-us/articles/4407116112539-Using-License-Keys
+      """)
 
 import_config "#{Mix.env()}.exs"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GEO.Mixfile do
   def project do
     [
       app: :geo,
-      version: "1.4.3",
+      version: "1.4.4",
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Closes #4