### PR TITLE
Allow to completely disable DB refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 
 ## Installation
 
-
 ```elixir
 def deps do
-  [{:geo, git: "git@github.com:platogo/geoip-elixir.git"}, tag: "1.0.0"]
+  [{:geo, git: "git@github.com:platogo/geoip-elixir.git"}, tag: "1.4.5"]
 end
 ```
 
@@ -17,10 +16,18 @@ config :geo,
   maxmind_license_key: "your key"
 ```
 
+You can also set the env variable `MAXMIND_LICENSE_KEY`.
+
 Use Geolix lookup functions to query for IP addresses. See Geolix readme for further details.
 
 ```elixir
 Geolix.lookup("8.8.8.8")
 ```
 
+## Configuration
 
+You can manually disable database refresh completely (useful for tests which don't need the GeoIP database):
+
+```elixir
+config :geo, :disable_refresh, true
+```

--- a/lib/geo/database.ex
+++ b/lib/geo/database.ex
@@ -1,6 +1,14 @@
 defmodule GEO.Database do
-  def source_path do
-    Application.get_env(:geo, :database_path, "#{:code.priv_dir(:geo)}")
-     |> Path.join("ip_database.tar.gz")
+  @moduledoc false
+
+  @doc """
+  Returns the path to the GeoIP database tarball.
+  """
+  @spec source_path(file_name :: binary) :: binary
+  def source_path(file_name \\ "ip_database.tar.gz") do
+    Path.join(
+      Application.get_env(:geo, :database_path, "#{:code.priv_dir(:geo)}"),
+      file_name
+    )
   end
 end

--- a/lib/geo/database/refresh.ex
+++ b/lib/geo/database/refresh.ex
@@ -69,7 +69,7 @@ defmodule GEO.Database.Refresh do
       !File.exists?(GEO.Database.source_path()) ->
         true
 
-      database_time_diff() >= @refresh_interval / 1000 - 60 ->
+      database_expired?() ->
         true
 
       true ->
@@ -80,6 +80,10 @@ defmodule GEO.Database.Refresh do
   defp database_time_diff do
     :calendar.datetime_to_gregorian_seconds(:calendar.universal_time()) -
       :calendar.datetime_to_gregorian_seconds(database_last_modified())
+  end
+
+  defp database_expired? do
+    database_time_diff() >= @refresh_interval / 1000 - 60
   end
 
   defp database_last_modified do

--- a/lib/geo/database/refresh.ex
+++ b/lib/geo/database/refresh.ex
@@ -1,58 +1,85 @@
 defmodule GEO.Database.Refresh do
+  @moduledoc """
+  GeoIP database refresh GenServer behaviour implementation.
+
+  The worker will download the GeoIP database if it is missing, and will redownload it if it becomes expired.
+  """
   require Logger
 
   use GenServer
 
   @name __MODULE__
-  @minutes_2 2 * 60 * 1000
-  @hours_24 24 * 60 * 60 * 1000
-  @refresh_interval @hours_24
+  @refresh_interval :timer.hours(24)
 
+  # Client API
+
+  @spec start_link([]) :: :ignore | {:error, any} | {:ok, pid}
   def start_link([]) do
     GenServer.start_link(@name, :ok, name: @name)
   end
 
-  def init(:ok) do
-    Process.send(self(), :refresh, [])
-    {:ok, nil}
-  end
-
-  def handle_info(:refresh, state) do
-    case refresh() do
-      :ok -> Process.send_after(self(), :refresh, @refresh_interval)
-      :error -> Process.send_after(self(), :refresh, @minutes_2)
-    end
-
-    {:noreply, state}
-  end
-
+  @spec refresh(boolean()) :: :error | :ok
   def refresh(reload \\ true) do
     if refresh?() do
-      with {:ok, file} <- download_database(),
-           :ok <- write_database(file) do
-        case reload do
-          true -> Geolix.reload_databases()
-          false -> :ok
-        end
+      with {:ok, file} <- do_download_database(),
+           :ok <- File.write(GEO.Database.source_path(), file) do
+        if(reload, do: Geolix.reload_databases())
       else
-        :ignore -> :ok
-        _ -> :error
+        :ignore ->
+          :ok
+
+        {:error, error} ->
+          Logger.error("Failed to refresh database, reason: #{error}")
+          :error
+
+        _ ->
+          :error
       end
     else
       :ok
     end
   end
 
+  # Callbacks
+
+  @impl true
+  @spec init(:ok) :: {:ok, nil}
+  def init(:ok) do
+    Process.send(self(), :refresh, [])
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_info(:refresh, state) do
+    case refresh() do
+      :ok -> Process.send_after(self(), :refresh, @refresh_interval)
+      :error -> Process.send_after(self(), :refresh, :timer.minutes(2))
+    end
+
+    {:noreply, state}
+  end
+
+  # Decides whether to refresh the GeoIP DB. It will be refreshed if the file does not exist yet or it is
+  # older than the refresh interval
   defp refresh? do
-    case File.exists?(GEO.Database.source_path()) do
-      false -> true
-      true -> database_time_diff() >= @refresh_interval / 1000 - 60
+    cond do
+      Application.get_env(:geo, :disable_refresh) ->
+        false
+
+      !File.exists?(GEO.Database.source_path()) ->
+        true
+
+      database_time_diff() >= @refresh_interval / 1000 - 60 ->
+        true
+
+      true ->
+        false
     end
   end
 
   defp database_time_diff do
-    (:calendar.universal_time() |> :calendar.datetime_to_gregorian_seconds()) -
-      (database_last_modified() |> :calendar.datetime_to_gregorian_seconds())
+    :calendar.datetime_to_gregorian_seconds(:calendar.universal_time()) -
+      :calendar.datetime_to_gregorian_seconds(database_last_modified())
   end
 
   defp database_last_modified do
@@ -61,29 +88,13 @@ defmodule GEO.Database.Refresh do
     |> Map.fetch!(:mtime)
   end
 
-  defp download_database do
-    Application.get_env(:geo, :maxmind_license_key)
-    |> do_download_database()
-  end
-
-  defp do_download_database("IGNORE"), do: :ignore
-
-  defp do_download_database(license_key) do
+  defp do_download_database(license_key \\ Application.get_env(:geo, :maxmind_license_key)) do
     url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoIP2-City&suffix=tar.gz"
     Logger.info("Downloading IP database")
 
     case HTTPoison.get("#{url}&license_key=#{license_key}") do
       {:ok, %HTTPoison.Response{body: body, status_code: 200}} -> {:ok, body}
       _ -> :error
-    end
-  end
-
-  defp write_database(:ignore), do: :ignore
-
-  defp write_database(file) do
-    case File.write(GEO.Database.source_path(), file) do
-      :ok -> :ok
-      {:error, _} -> :error
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GEO.Mixfile do
   def project do
     [
       app: :geo,
-      version: "1.4.4",
+      version: "1.4.5",
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
It is very annoying when Geo tries to keep redownloading the database in other Elixir apps, especially when running in dev/test Mix env.

Also refactored the Refresh GenServer.

Closes #6 