### PR TITLE
Clean: Change database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Wrapper around Geolix that supports periodic refresh of the GeoIP database.
 
 ```elixir
 def deps do
-  [{:geo, git: "git@github.com:platogo/geoip-elixir.git"}, tag: "1.4.6"]
+  [{:geo, git: "git@github.com:platogo/geoip-elixir.git"}, tag: "1.4.7"]
 end
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,12 +2,6 @@ import Config
 
 config :geo,
   maxmind_license_key:
-    System.get_env("MAXMIND_LICENSE_KEY") ||
-      raise("""
-      environment variable MAXMIND_LICENSE_KEY not set
-      This key is needed to download the IP database
-
-      For more information, refer to https://support.maxmind.com/hc/en-us/articles/4407116112539-Using-License-Keys
-      """)
+    System.get_env("MAXMIND_LICENSE_KEY")
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,27 @@
 import Config
+
+config :geo,
+  disable_refresh: true
+
+config :geolix,
+  databases: [
+    %{
+      id: :city,
+      adapter: Geolix.Adapter.Fake,
+      data: %{
+        {1, 1, 1, 1} => %{country: %{iso_code: "AT"}, location: %{time_zone: "Europe/Vienna"}},
+        {2, 2, 2, 2} => %{country: %{iso_code: "HU"}, location: %{time_zone: "Europe/Budapest"}},
+      }
+    }
+  ]
+  # databases: [
+  #   %{
+  #     id: :city,
+  #     adapter: Geolix.Adapter.MMDB2,
+  #     source:
+  #       System.get_env(
+  #         "GEOLIX_DATABASE_PATH",
+  #         Path.expand("#{__DIR__}/../priv/geo/ip_database.tar.gz")
+  #       )
+  #   }
+  # ]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,20 @@
+import Config
+
+geolix_database_path =
+  System.get_env(
+    "GEOLIX_DATABASE_PATH",
+    Path.expand("#{__DIR__}/../priv/geo/ip_database.tar.gz")
+  )
+
+config :geo,
+  disable_refresh: true,
+  database_path: geolix_database_path
+
+config :geolix,
+  databases: [
+    %{
+      id: :city,
+      adapter: Geolix.Adapter.MMDB2,
+      source: geolix_database_path
+    }
+  ]

--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -2,22 +2,12 @@ defmodule GEO do
   use Application
 
   def start(_type, _args) do
-    configure_ip_database()
-
     children = [
       GEO.Database.Refresh
     ]
 
     options = [strategy: :one_for_one, name: GEO.Supervisor]
     Supervisor.start_link(children, options)
-  end
-
-  defp configure_ip_database() do
-    Geolix.load_database(%{
-      id: :city,
-      adapter: Geolix.Adapter.MMDB2,
-      source: GEO.Database.source_path()
-    })
   end
 
   # Refresh database file during compilation

--- a/lib/geo/database.ex
+++ b/lib/geo/database.ex
@@ -4,11 +4,8 @@ defmodule GEO.Database do
   @doc """
   Returns the path to the GeoIP database tarball.
   """
-  @spec source_path(file_name :: binary) :: binary
-  def source_path(file_name \\ "ip_database.tar.gz") do
-    Path.join(
-      Application.get_env(:geo, :database_path, "#{:code.priv_dir(:geo)}"),
-      file_name
-    )
+  @spec source_path() :: binary
+  def source_path() do
+    Application.fetch_env!(:geo, :database_path)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GEO.Mixfile do
   def project do
     [
       app: :geo,
-      version: "1.4.6",
+      version: "1.4.7",
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- Use geolix config to set up database adapter
- Use GEOLIX_DATABASE_PATH instead of magic to configure the path
- Use `Geolix.Adapter.Fake` for `dev` env
- Do not raise but fail gracefully in `dev` when MAXMIND_LICENSE_KEY is missing

Co-authored-by: Grzegorz Jakubiak <gregg@platogo.com>