### PR TITLE
Fix: Database config for downloading geolix data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Wrapper around Geolix that supports periodic refresh of the GeoIP database.
 
 ```elixir
 def deps do
-  [{:geo, git: "git@github.com:platogo/geoip-elixir.git"}, tag: "1.4.7"]
+  [{:geo, git: "git@github.com:platogo/geoip-elixir.git"}, tag: "1.4.8"]
 end
 ```
 
@@ -32,3 +32,43 @@ You can manually disable database refresh completely (useful for tests which don
 ```elixir
 config :geo, :disable_refresh, true
 ```
+
+In order to use a fake database, add something similar to the following configuration to your configuration:
+
+```elixir
+config :geolix,
+  databases: [
+    %{
+      id: :city,
+      adapter: Geolix.Adapter.Fake,
+      data: %{
+        {1, 1, 1, 1} => %{country: %{iso_code: "AT"}, location: %{time_zone: "Europe/Vienna"}},
+        {2, 2, 2, 2} => %{country: %{iso_code: "HU"}, location: %{time_zone: "Europe/Budapest"}},
+      }
+    }
+  ]
+```
+
+In order to use a downloaded database, use the following:
+
+```elixir
+geolix_database_path = "/absolute/path/to/ip_database.tar.gz"
+
+config :geo,
+  disable_refresh: false,
+  database_path: geolix_database_path
+
+config :geolix,
+  databases: [
+    %{
+      id: :city,
+      adapter: Geolix.Adapter.MMDB2,
+      source: geolix_database_path
+    }
+  ]
+```
+
+## TODO
+
+This should be changed so we no longer use `Application.get_env/2` for configuration, supervision is handled in the including
+application, and `Task` is preferred over `GenServer`.

--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -13,7 +13,7 @@ defmodule GEO do
   # Refresh database file during compilation
   {:ok, _started} = Application.ensure_all_started(:httpoison)
 
-  case GEO.Database.Refresh.refresh(false) do
+  case GEO.Database.Refresh.refresh() do
     :ok -> :ok
     :error -> raise "Could not refresh IP database"
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GEO.Mixfile do
   def project do
     [
       app: :geo,
-      version: "1.4.7",
+      version: "1.4.8",
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
We were missing a force download of the database on startup of the `geo` application.